### PR TITLE
add paid storage diff field for internal operation result

### DIFF
--- a/rpc/block.go
+++ b/rpc/block.go
@@ -194,6 +194,7 @@ type OperationResult struct {
 	ConsumedGas                  string           `json:"consumed_gas,omitempty"`
 	ConsumedMilliGas             string           `json:"consumed_milligas,omitempty"`
 	StorageSize                  string           `json:"storage_size,omitempty"`
+	PaidStorageSizeDiff          string           `json:"paid_storage_size_diff,omitempty"`
 	AllocatedDestinationContract bool             `json:"allocated_destination_contract,omitempty"`
 	Errors                       []ResultError    `json:"errors,omitempty"`
 }


### PR DESCRIPTION
Hello, I'm currently working on a project where we use your fork, as it is the most active

In the same way as you added "consumed_milligas"
Could you please add "paid_storage_size_diff" to "internal_operation_results" 

Thanks !